### PR TITLE
Refactor of the CanvassForm component

### DIFF
--- a/src/app/tool/canvassr/CanvassForm.jsx
+++ b/src/app/tool/canvassr/CanvassForm.jsx
@@ -1,95 +1,68 @@
-import { useRef } from 'react';
-import H2 from '../../ui/typography/H2';
-import CanvassInput from './CanvassInput';
+import { useState } from 'react';
 import CanvassButton from './CanvassButton';
+
+const formPlaceHolders = {
+  'First Name': 'first_name',
+  'Last Name': 'last_name',
+  'Email Address': 'email',
+  'Phone Number': 'phone',
+  'Address Line 1': 'address',
+  City: 'city',
+};
+
+const initialFormData = {
+  first_name: '',
+  last_name: '',
+  phone: '',
+  email: '',
+  address: '',
+  city: '',
+  state: '',
+  notes: '',
+};
+
 export default function CanvassForm({ formAction }) {
-  // TODO: #1 Ref refactor this.
-  let firstNameRef = useRef(null);
-  let lastNameRef = useRef(null);
-  let phoneRef = useRef(null);
-  let emailRef = useRef(null);
-  let addressRef = useRef(null);
-  let cityRef = useRef(null);
-  let stateRef = useRef(null);
-  let noteRef = useRef(null);
+  const [formData, setFormData] = useState(initialFormData);
 
   function clearInputs() {
-    firstNameRef.current.value = '';
-    lastNameRef.current.value = '';
-    emailRef.current.value = '';
-    phoneRef.current.value = '';
-    addressRef.current.value = '';
-    cityRef.current.value = '';
-    stateRef.current.selectedIndex = 0;
-    noteRef.current.value = '';
+    setFormData(initialFormData);
   }
 
   function handleSubmit() {
-    let newFirstName = firstNameRef.current.value.trim();
-    let newLastName = lastNameRef.current.value.trim();
-    let newPhone = phoneRef.current.value.trim();
-    let newEmail = emailRef.current.value.trim();
-    let newAddress = addressRef.current.value.trim();
-    let newCity = cityRef.current.value.trim();
-    let newState = stateRef.current.value.trim();
-    let newNotes = noteRef.current.value.trim();
-
-    let entry = {
-      first_name: newFirstName,
-      last_name: newLastName,
-      phone: newPhone,
-      email: newEmail,
-      address: newAddress,
-      city: newCity,
-      state: newState,
-      notes: newNotes,
-    };
-    // TODO: #2 Error message if fields empty
-    if (!newFirstName || !newLastName || !newEmail) return;
-    clearInputs();
+    const entry = formData;
+    if (!entry.first_name || !entry.last_name || !entry.email) {
+      alert('Please fill in name and email fields, they are required.');
+      return;
+    }
+    console.log(formData);
     formAction(entry);
+    clearInputs();
   }
 
   return (
     <div className="flex flex-col">
-      <CanvassInput
+      {Object.keys(formPlaceHolders).map((item) => (
+        <input
+          className="text-slate-600 p-1"
+          name={item}
+          key={item}
+          placeholder={item}
+          value={formData[formPlaceHolders[item]]}
+          onChange={(e) => {
+            setFormData({
+              ...formData,
+              [formPlaceHolders[item]]: e.target.value,
+            });
+          }}
+        />
+      ))}
+      <select
         className="text-slate-600 p-1"
-        ref={firstNameRef}
-        required
-        placeholder="First Name"
-      />
-      <CanvassInput
-        className="text-slate-600 p-1"
-        ref={lastNameRef}
-        required
-        placeholder="Last Name"
-      />
-      <CanvassInput
-        className="text-slate-600 p-1"
-        ref={emailRef}
-        required
-        placeholder="Email Address"
-        type="email"
-      />
-      <CanvassInput
-        className="text-slate-600 p-1"
-        ref={phoneRef}
-        placeholder="Phone Number"
-        type="number"
-      />
-      <CanvassInput
-        className="text-slate-600 p-1"
-        ref={addressRef}
-        placeholder="Address Line 1"
-        type="text"
-      />
-      <CanvassInput
-        className="text-slate-600 p-1"
-        ref={cityRef}
-        placeholder="City"
-        type="text"
-      />
-      <select className="text-slate-600 p-1" ref={stateRef}>
+        value={formData.state}
+        onChange={(e) => {
+          setFormData({ ...formData, state: e.target.value });
+        }}
+      >
         <option value="">State</option>
         <option value="AL">Alabama</option>
         <option value="AK">Alaska</option>
@@ -144,10 +117,13 @@ export default function CanvassForm({ formAction }) {
       </select>
       <textarea
         className="text-slate-600 p-1"
-        ref={noteRef}
         placeholder="Notes Here"
         cols="10"
         rows="10"
+        value={formData.notes}
+        onChange={(e) => {
+          setFormData({ ...formData, notes: e.target.value });
+        }}
       ></textarea>
 
       <CanvassButton


### PR DESCRIPTION
First of all, I am aware that this commit may be considered outside the scope of the open issues, I understand if this does not get merged. It primarily addresses open issue #1, but goes a little further.

This pull request is a fairly heavy refactor of the form component for Canvassr. The goal was to reduce or remove the repeated calls to useRef, the repeated invocations of the CanvassInput component, and just generally streamline.

The individual refs for the form fields have been replaced with an object stored in state. The state changes will cause more re-renders, but that is unlikely to be a performance issue for this application, and the benefit of using state  over refs is to make form validations/submit disabling easier in future feature additions.

I have used a mapping of inputs for the form fields that are inputs, removing the need for the custom input component.

I have also implemented an alert if the form is submitted without required fields, to address issue #2.

If the maintainers like this commit and choose to merge, I will also extend the streamlining of this component by replacing the repeated <option> components with a map to an object containing the state data. This will be useful if the state data needs to be accessed by other components in the future.