### PR TITLE
Address Issue #14: Seperate state select component

### DIFF
--- a/src/app/tool/canvassr/CanvassForm.jsx
+++ b/src/app/tool/canvassr/CanvassForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import CanvassButton from './CanvassButton';
+import CanvassStateSelect from './CanvassStateSelect';
 import { inputClasses } from '@/app/ui/classes';
 
 const formPlaceHolders = {
@@ -57,65 +58,14 @@ export default function CanvassForm({ formAction }) {
           }}
         />
       ))}
-      <select
+      <CanvassStateSelect
         className={inputClasses}
         value={formData.state}
         onChange={(e) => {
           setFormData({ ...formData, state: e.target.value });
         }}
-      >
-        <option value="">State</option>
-        <option value="AL">Alabama</option>
-        <option value="AK">Alaska</option>
-        <option value="AZ">Arizona</option>
-        <option value="AR">Arkansas</option>
-        <option value="CA">California</option>
-        <option value="CO">Colorado</option>
-        <option value="CT">Connecticut</option>
-        <option value="DE">Delaware</option>
-        <option value="FL">Florida</option>
-        <option value="GA">Georgia</option>
-        <option value="HI">Hawaii</option>
-        <option value="ID">Idaho</option>
-        <option value="IL">Illinois</option>
-        <option value="IN">Indiana</option>
-        <option value="IA">Iowa</option>
-        <option value="KS">Kansas</option>
-        <option value="KY">Kentucky</option>
-        <option value="LA">Louisiana</option>
-        <option value="ME">Maine</option>
-        <option value="MD">Maryland</option>
-        <option value="MA">Massachusetts</option>
-        <option value="MI">Michigan</option>
-        <option value="MN">Minnesota</option>
-        <option value="MS">Mississippi</option>
-        <option value="MO">Missouri</option>
-        <option value="MT">Montana</option>
-        <option value="NE">Nebraska</option>
-        <option value="NV">Nevada</option>
-        <option value="NH">New Hampshire</option>
-        <option value="NJ">New Jersey</option>
-        <option value="NM">New Mexico</option>
-        <option value="NY">New York</option>
-        <option value="NC">North Carolina</option>
-        <option value="ND">North Dakota</option>
-        <option value="OH">Ohio</option>
-        <option value="OK">Oklahoma</option>
-        <option value="OR">Oregon</option>
-        <option value="PA">Pennsylvania</option>
-        <option value="RI">Rhode Island</option>
-        <option value="SC">South Carolina</option>
-        <option value="SD">South Dakota</option>
-        <option value="TN">Tennessee</option>
-        <option value="TX">Texas</option>
-        <option value="UT">Utah</option>
-        <option value="VT">Vermont</option>
-        <option value="VA">Virginia</option>
-        <option value="WA">Washington</option>
-        <option value="WV">West Virginia</option>
-        <option value="WI">Wisconsin</option>
-        <option value="WY">Wyoming</option>
-      </select>
+      />
+
       <textarea
         className={inputClasses}
         placeholder="Notes Here"

--- a/src/app/tool/canvassr/CanvassStateSelect.jsx
+++ b/src/app/tool/canvassr/CanvassStateSelect.jsx
@@ -1,0 +1,67 @@
+const statesValues = {
+  '': 'State',
+  AL: 'Alabama',
+  AK: 'Alaska',
+  AZ: 'Arizona',
+  AR: 'Arkansas',
+  CA: 'California',
+  CO: 'Colorado',
+  CT: 'Connecticut',
+  DE: 'Delaware',
+  FL: 'Florida',
+  GA: 'Georgia',
+  HI: 'Hawaii',
+  ID: 'Idaho',
+  IL: 'Illinois',
+  IN: 'Indiana',
+  IA: 'Iowa',
+  KS: 'Kansas',
+  KY: 'Kentucky',
+  LA: 'Louisiana',
+  ME: 'Maine',
+  MD: 'Maryland',
+  MA: 'Massachusetts',
+  MI: 'Michigan',
+  MN: 'Minnesota',
+  MS: 'Mississippi',
+  MO: 'Missouri',
+  MT: 'Montana',
+  NE: 'Nebraska',
+  NV: 'Nevada',
+  NH: 'New Hampshire',
+  NJ: 'New Jersey',
+  NM: 'New Mexico',
+  NY: 'New York',
+  NC: 'North Carolina',
+  ND: 'North Dakota',
+  OH: 'Ohio',
+  OK: 'Oklahoma',
+  OR: 'Oregon',
+  PA: 'Pennsylvania',
+  RI: 'Rhode Island',
+  SC: 'South Carolina',
+  SD: 'South Dakota',
+  TN: 'Tennessee',
+  TX: 'Texas',
+  UT: 'Utah',
+  VT: 'Vermont',
+  VA: 'Virginia',
+  WA: 'Washington',
+  WV: 'West Virginia',
+  WI: 'Wisconsin',
+  WY: 'Wyoming',
+};
+
+const CanvassStateSelect = (props) => {
+  return (
+    <select {...props}>
+      {Object.keys(statesValues).map((value) => (
+        <option key={value} value={value}>
+          {statesValues[value]}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default CanvassStateSelect;


### PR DESCRIPTION
Pretty self explanatory PR here, directly addressing issue #14

The component spreads props handed from parent to the outer select element, so state handlers should be passed in as props to the component. 

The actual data for the state names and values has been moved to an object external to the jsx, for more readability, and so that if the state data needs to be re-used in other components or route handlers in the future, the object can be moved to a central export from a utils file.